### PR TITLE
Use string cmp instead of regex; simplify use of for select loop.

### DIFF
--- a/httpstress.go
+++ b/httpstress.go
@@ -10,7 +10,7 @@ package httpstress
 import (
 	"errors"
 	"net/http"
-	"regexp"
+	"strings"
 )
 
 // Library version
@@ -42,7 +42,7 @@ Returns map: {url}, {fail count} or error (failed URL message). Example:
 */
 func Test(conn int, max int, urls []string) (results map[string]int, err error) {
 	for _, i := range urls {
-		if m, _ := regexp.MatchString("^https?://", i); !m {
+		if !strings.HasPrefix(i, "http://") && !strings.HasPrefix(i, "https://") {
 			err = errors.New("Not a HTTP/HTTPS URL: " + i)
 			return
 		}
@@ -90,11 +90,8 @@ func Test(conn int, max int, urls []string) (results map[string]int, err error) 
 }
 
 func logger(failures <-chan string, results map[string]int) {
-	for {
-		select {
-		case url := <-failures:
-			results[url]++
-		}
+	for url := range failures {
+		results[url]++
 	}
 }
 


### PR DESCRIPTION
First change is really a performance improvement; the second is style only (I think.)